### PR TITLE
feat: add folder dropdown menu

### DIFF
--- a/src/features/courses/drop-down-menu.tsx
+++ b/src/features/courses/drop-down-menu.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { FiPlus, FiEdit2, FiUserPlus, FiTrash } from 'react-icons/fi'
+import { RiFolderTransferLine } from 'react-icons/ri'
+
+const menuItems = [
+  { icon: FiPlus, label: 'New folder' },
+  { icon: FiEdit2, label: 'Rename' },
+  { icon: FiUserPlus, label: 'Share' },
+  { icon: RiFolderTransferLine, label: 'Move' },
+  { icon: FiTrash, label: 'Delete' },
+]
+
+
+export default function DropdownMenu() {
+    return (
+      <div
+      style={{
+        width: '180px',
+        height: '212px',
+        borderRadius: '15px',
+        boxShadow: '0px 0px 25px 10px #00000038',
+      }}
+      className="absolute z-50 mt-2 bg-[#222222] text-white rounded-md shadow-lg p-2 space-y-1"
+      >
+        {menuItems.map(({ icon: Icon, label }) => (
+          <button key={label} className="w-full text-left px-3 py-2 hover:bg-[#333] rounded flex items-center gap-4">
+            <Icon className="shrink-0" />
+            {label}
+          </button>
+        ))}
+      </div>
+    )
+  }

--- a/src/features/courses/drop-down-menu.tsx
+++ b/src/features/courses/drop-down-menu.tsx
@@ -10,24 +10,17 @@ const menuItems = [
   { icon: FiTrash, label: 'Delete' },
 ]
 
-
 export default function DropdownMenu() {
-    return (
-      <div
-      style={{
-        width: '180px',
-        height: '212px',
-        borderRadius: '15px',
-        boxShadow: '0px 0px 25px 10px #00000038',
-      }}
-      className="absolute z-50 mt-2 bg-[#222222] text-white rounded-md shadow-lg p-2 space-y-1"
-      >
-        {menuItems.map(({ icon: Icon, label }) => (
-          <button key={label} className="w-full text-left px-3 py-2 hover:bg-[#333] rounded flex items-center gap-4">
-            <Icon className="shrink-0" />
-            {label}
-          </button>
-        ))}
-      </div>
-    )
-  }
+  return (
+    <div
+      className="absolute z-50 mt-2 bg-[#222222] text-white w-[180px] h-[212px] rounded-[15px] shadow-[0px_0px_25px_10px_#00000038] p-2 space-y-1"
+    >
+      {menuItems.map(({ icon: Icon, label }) => (
+        <button key={label} className="w-full text-left px-3 py-2 hover:bg-[#333] rounded flex items-center gap-4">
+          <Icon className="shrink-0" />
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/features/courses/folder-bread-crumb.tsx
+++ b/src/features/courses/folder-bread-crumb.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { FiChevronRight } from 'react-icons/fi'
+import { HiDotsHorizontal } from 'react-icons/hi'
+import DropdownMenu from './drop-down-menu'
+
+type FolderBreadcrumbProps = {
+  currentPath: string[]
+  onNavigate: (path: string[]) => void
+  dropdownRef: React.RefObject<HTMLDivElement | null> 
+  showDropdown: boolean
+  toggleDropdown: () => void
+}
+
+export default function FolderBreadcrumb({
+  currentPath,
+  onNavigate,
+  dropdownRef,
+  showDropdown,
+  toggleDropdown,
+}: FolderBreadcrumbProps) {
+  return (
+    <div className="flex flex-row flex-nowrap items-center text-[14px] font-semibold tracking-wide text-[#b9b8b8] space-x-1">
+      <span
+        className={`cursor-pointer hover:underline ${
+          currentPath.length === 0 ? 'text-text-secondary ' : ''
+        }`}
+        onClick={() => onNavigate([])}
+      >
+        Folders
+      </span>
+
+      {currentPath.map((folder: string, idx: number) => (
+        <span key={idx} className="inline-flex items-center group relative">
+          <FiChevronRight className="text-text-secondary mx-2 text-lg" />
+          <span className="flex items-center gap-1">
+            <span
+              className={`cursor-pointer hover:underline ${
+                idx === currentPath.length - 1 ? 'text-text-secondary' : ''
+              }`}
+              onClick={() => onNavigate(currentPath.slice(0, idx + 1))}
+            >
+              {folder}
+            </span>
+
+            {idx === currentPath.length - 1 && (
+              <div className="relative" ref={dropdownRef}>
+                <button
+                  onClick={toggleDropdown}
+                  className={`ml-1 p-1 rounded hover:bg-[#333] inline-flex transition-opacity ${
+                    showDropdown ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                  }`}
+                >
+                  <HiDotsHorizontal className="text-[#a1a0a0] hover:text-text-secondary w-[16px] h-[16px]" />
+                </button>
+
+                {showDropdown && <DropdownMenu />}
+              </div>
+            )}
+          </span>
+        </span>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
📌 **Summary**  
- Added a dropdown menu with folder actions and icons

🛠️ **Type of Change**  
- [x] Feature  
- [ ] Bugfix  
- [ ] Refactor  
- [ ] Documentation  
- [ ] Other: __________

✅ **What's Changed**  
- Added a dropdown menu with folder actions and icons in `Course` page

🧪 **How to Test**  
- Manual testing by opening the `course page` and clicking on a folder to show the folder name in the bread crumbs menu above the folders
- Click on the three dots that appear next to the folder name to show a drop down with the actions that can be performed
![Screenshot 2025-05-09 151106](https://github.com/user-attachments/assets/f71216f0-631d-4242-b983-9387cabd7fa2)

🚨 **Checklist**  
Mark items when complete – helps reviewers know what’s done.

- [ ] Tested on all major browsers  
- [ ] Mobile responsive  
- [ ] Accessibility checked (focus states, keyboard nav)  
- [ ] Unit tests written  
- [x] No console warnings/errors  
- [x] PR follows our coding standards / linters  
